### PR TITLE
Fix use of `tbb` on linux-64

### DIFF
--- a/recipe/build_libthermo.sh
+++ b/recipe/build_libthermo.sh
@@ -3,9 +3,9 @@ mkdir build
 cd build
 
 if [[ $build_platform == "osx-64" ]]; then
-    set TBB_SWITCH=OFF
+    export TBB_SWITCH=OFF
 else
-    set TBB_SWITCH=ON
+    export TBB_SWITCH=ON
 fi
 if [[ $PKG_NAME == "libthermo" ]]; then
     cmake .. ${CMAKE_ARGS}              \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - libthermo.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libthermo


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
