### PR TITLE
Add python 3.14 and remove abi3

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,7 +14,15 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
 - '1.88'
-python_min:
-- '3.10'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 target_platform:
 - linux-64

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,43 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+    additional_zip_keys:
+        - channel_sources
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false
+channel_sources:
+- conda-forge,conda-forge/label/python_rc

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,7 +8,15 @@ cxx_compiler:
 - vs2022
 libboost_devel:
 - '1.88'
-python_min:
-- '3.10'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 target_platform:
 - win-64

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: libthermo
-  version: "0.4.0"
-  python_min: "3.12"
+  version: "0.4.1"
+  python_min: "3.11"
 
 recipe:
   name: ${{ name|lower }}
@@ -9,10 +9,10 @@ recipe:
 
 source:
   url: https://github.com/twiinIT/libthermo/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 01388272ae03ecd295c083be012543a9a82b7a22db2dec5a5dc898ccb486771c
+  sha256: d3f0e43191b5a7a48cc656c2ceee773cba7b31567420c5b799f7b51d8681977a
 
 build:
-  number: 2
+  number: 0
   skip: ["osx"]
 
 outputs:
@@ -45,8 +45,6 @@ outputs:
   - package:
       name: pythermo
     build:
-      python:
-        version_independent: true
       script: python -m pip install ./pythermo --no-deps --ignore-installed --no-build-isolation --no-cache-dir -vvv
     requirements:
       build:
@@ -55,14 +53,13 @@ outputs:
         - cmake
         - ninja
         - libthermo
-        - libboost-devel
       host:
-        - python=${{ python_min }}
+        - python
         - pip
         - nanobind
         - scikit-build-core
       run:
-        - python>=${{ python_min }}
+        - python
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,7 @@ recipe:
 
 source:
   url: https://github.com/twiinIT/libthermo/archive/refs/tags/${{ version }}.tar.gz
-  sha256: d3f0e43191b5a7a48cc656c2ceee773cba7b31567420c5b799f7b51d8681977a
+  sha256: 546a076359b11959f6ac80844ec558c7403241bfa9f4e3be23cbbbc146ad5c2e
 
 build:
   number: 0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -52,12 +52,13 @@ outputs:
         - ${{ stdlib("c") }}
         - cmake
         - ninja
-        - libthermo
       host:
         - python
         - pip
         - nanobind
         - scikit-build-core
+        - libboost-devel
+        - libthermo
       run:
         - python
     tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,7 @@ recipe:
 
 source:
   url: https://github.com/twiinIT/libthermo/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 546a076359b11959f6ac80844ec558c7403241bfa9f4e3be23cbbbc146ad5c2e
+  sha256: 25e9c7dc7c3ce0b208c8a2a61b3a80671384dde58fabfcca1276e458e1246307
 
 build:
   number: 0


### PR DESCRIPTION
remove abi3 constraint
bump to 0.4.1

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
